### PR TITLE
feat(livekit-plugins-google): structured responses for Live API tool calls

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -84,15 +84,15 @@ def get_tool_results_for_realtime(
 ) -> types.LiveClientToolResponse | None:
     function_responses: list[types.FunctionResponse] = []
     for msg in chat_ctx.items:
-        if msg.type == "function_call_output":
-            try:
-                output = ast.literal_eval(msg.output)
-            except:
-                output = {"output": msg.output}
-
+        # If there is no output, skip the message.
+        if msg.type == "function_call_output" and msg.output:
             res = types.FunctionResponse(
                 name=msg.name,
-                response=output,
+                # LiveKit sets output to the string representation of the tool's
+                # return value, but the Live API expects the actual value.
+                # https://ai.google.dev/gemini-api/docs/live-tools#function-calling
+                response=ast.literal_eval(msg.output),
+                scheduling=types.FunctionResponseScheduling.SILENT,
             )
             if not vertexai:
                 # vertexai does not support id in FunctionResponse

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import re
 from copy import deepcopy
 from typing import Any
@@ -84,15 +85,21 @@ def get_tool_results_for_realtime(
     function_responses: list[types.FunctionResponse] = []
     for msg in chat_ctx.items:
         if msg.type == "function_call_output":
+            try:
+                output = ast.literal_eval(msg.output)
+            except:
+                output = {"output": msg.output}
+
             res = types.FunctionResponse(
                 name=msg.name,
-                response={"output": msg.output},
+                response=output,
             )
             if not vertexai:
                 # vertexai does not support id in FunctionResponse
                 # see: https://github.com/googleapis/python-genai/blob/85e00bc/google/genai/_live_converters.py#L1435
                 res.id = msg.call_id
             function_responses.append(res)
+    logger.debug("get_tool_results_for_realtime: function_responses=%s", function_responses)
     return (
         types.LiveClientToolResponse(function_responses=function_responses)
         if function_responses


### PR DESCRIPTION
LiveKit automatically converts the result of a tool call to a string ([reference](https://docs.livekit.io/agents/build/tools/#return-value)), and this string was being returned in the [Live API](https://ai.google.dev/gemini-api/docs/live-tools) `FunctionResponse.response` as `output`. So, for example:

```py
@function_tool()
async def lookup_weather(self, context: RunContext, location: str) -> dict[str, Any]:
    return {"weather": "sunny", "temperature_f": 70}
```

Would get returned to the Live API as:

```json
{
  "output": "{'weather': 'sunny', 'temperature_f': 70}"
}
```

However, our Live API integration requires returning the _actual_ result, not the string representation.

With this change, we:
1. Do not return a `FunctionResponse` if the tool call did not return anything.
2. Set `FunctionResponse.response` to the actual result by calling `ast.literal_eval` on the string representation.
3. Set `FunctionResponse.scheduling` to `SILENT` to let the model decide when to use the result ([reference](https://ai.google.dev/gemini-api/docs/live-tools#async-function-calling)).